### PR TITLE
feat: add usage help when no args

### DIFF
--- a/mq_build_qmgr_container.sh
+++ b/mq_build_qmgr_container.sh
@@ -52,7 +52,22 @@
 #     behavior. If you adopt it, test thoroughly in your environment.
 #   - Recommended linting with ShellCheck: https://www.shellcheck.net/
 # =============================================================================
- 
+
+usage() {
+  cat <<EOF
+Usage: $0 <number_of_qmgrs>
+
+Provision one or more IBM MQ queue managers as Docker containers.
+
+Arguments:
+  number_of_qmgrs  Positive integer specifying how many queue manager
+                   instances to create.
+
+Example:
+  $0 3
+EOF
+}
+
 # --------- CONFIG ---------
 # Number of queue managers to create; required positional argument.
 NUM_QMGRS="$1"
@@ -74,11 +89,18 @@ GREEN="\033[0;32m"
 YELLOW="\033[0;33m"
 CYAN="\033[0;36m"
 NC="\033[0m" # No Color
- 
+
 # --------- Validation ---------
+# Display usage and exit on -h/--help.
+if [[ "$NUM_QMGRS" == "-h" || "$NUM_QMGRS" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
 # Validate that NUM_QMGRS is a non-empty, positive integer.
-if [[ -z "$NUM_QMGRS" || ! "$NUM_QMGRS" =~ ^[0-9]+$ ]]; then
-  echo -e "${RED}❌ Usage: $0 <number_of_qmgrs>${NC}"
+if [[ -z "$NUM_QMGRS" || ! "$NUM_QMGRS" =~ ^[1-9][0-9]*$ ]]; then
+  echo -e "${RED}Error: missing or invalid <number_of_qmgrs>.${NC}\n"
+  usage
   exit 1
 fi
  
@@ -201,7 +223,7 @@ echo ""
 echo -e "${CYAN}👉 To connect to a container: ${NC}"
 echo -e "${CYAN}docker exec -it <container_name> bash${NC}"
 echo ""
- 
+
 # =============================================================================
 # End of file
 # =============================================================================


### PR DESCRIPTION
## Summary
- add usage() help text for mq_build_qmgr_container.sh
- handle -h/--help and show detailed usage when missing or invalid arguments

## Testing
- `bash -n mq_build_qmgr_container.sh`
- `./mq_build_qmgr_container.sh -h`
- `./mq_build_qmgr_container.sh` *(fails: missing argument)*
- `shellcheck mq_build_qmgr_container.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa49b2fccc832e9ab7e86880ae9386